### PR TITLE
Build system for AsciiDoc files that targets HTML, EPUB, and DOCX.

### DIFF
--- a/Asciidoctor.sublime-build
+++ b/Asciidoctor.sublime-build
@@ -1,0 +1,18 @@
+{
+    "selector": "text.asciidoc",
+    "working_dir": "$file_path",
+    "file_regex": "^asciidoctor:[^:]*:\\s+(\\w+\\.\\w+): line ([0-9]*)",
+    "shell_cmd": "asciidoctor -b html5 $file_name",
+    "variants": [
+        {
+            "name": "EPUB",
+            "shell_cmd": "asciidoctor-epub3 $file_name"
+        },
+        {
+            "name": "DOCX",
+            "windows": {
+              "shell_cmd": "call \"$packages\\ST4-Asciidoctor\\script\\Asciidoctor_build_docx.bat\" \"$file_path\" $file_base_name $file_extension"
+            }
+        }
+    ]
+}

--- a/docs-src/features.adoc
+++ b/docs-src/features.adoc
@@ -1,4 +1,8 @@
 = Package Features
+// The kbd:[] macros won't work unless the experimental attribute is turned on.
+:experimental: true
+:Y: Yes
+:N: No
 
 The list of editing features natively supported by the package.
 
@@ -122,3 +126,55 @@ Document and section titles are displayed in both the local and global _Goto Sym
 // This is no longer true with ST4:
 Furthermore, they will be on top of the list because of the precedence of `=`.
 ////
+
+
+== Build System
+
+This package defines a build system for AsciiDoc files that targets *HTML*, *EPUB*, and *DOCX*.
+With the source AsciiDoc file open in the editor, simply press kbd:[Ctrl]+kbd:[Shift]+kbd:[B] to invoke the build system, and then select your target.
+
+.Targets
+[opts="autowidth"]
+|=============================================================================
+| Asciidoctor        | Generates HTML
+| Asciidoctor - EPUB | Generates EPUB (via `asciidoctor-epub3`)
+| Asciidoctor - DOCX | Generates a Word document (via `pandoc`)
+|=============================================================================
+
+Or, press kbd:[Ctrl]+kbd:[B] to repeat the build for the last target selected.
+
+In all cases, the generated file will be placed alongside the source file, in the same folder.
+In the case of a DOCX file, it will be opened automatically using your system's default program for the DOCX file type.
+
+=== Build System Requirements
+
+* For HTML, this assumes that `asciidoctor` is installed on the system path.
+* For EPUB, this assumes that `asciidoctor-epub3` is installed on the system path.
+* For DOCX, this assumes that `pandoc` is installed on the system path (along with `asciidoctor`).
+
+NOTE: There is currently only a `Windows` implementation for DOCX.
+
+=== Specifying a reference.docx file for Pandoc
+
+Pandoc has the ability to start with a reference DOCX file that, for example, defines all of the paragraph and character styles you'd like to be included in the target.
+This build system supports three different ways to specify such a reference docx file for pandoc to use:
+
+. If the AsciiDoc source file contains an attribute definition for `:pandoc:`, `:pandoc-ref:`, or `:pandoc-reference:`, and the value of that attribute exists as a file, then it will be used.
+NOTE: There is nothing special about us using an attribute definition for this.
+This build system searches the source file directly for the file reference, so we could have buried it in a comment, for example.
+Using attribute syntax just seemed appropriate.
+By the time the source file is processed by AsciiDoctor, the `:pandoc...:` attribute will just be ignored.
+Be aware that if there are multiple `:pandoc...:` attributes defined in the file, only the last one will be used.
+Also, this script will only find `:pandoc...:` attributes that are in the main source file, not in any included files.
+
+. If `.\reference.docx` exists, it will be used.
+
+. If `.\.pandoc\reference.docx` exists, it will be used.
+
+. Otherwise, no reference file will be used.
+
+=== Usage Tips
+
+You can leave an *HMTL* file open in your browser while you regenerate it.
+Then, just refresh the page with kbd:[F5].
+For *EPUB* and *DOCX* files, however, you must close them before they can be regenerated.

--- a/script/Asciidoctor_build_docx.bat
+++ b/script/Asciidoctor_build_docx.bat
@@ -1,0 +1,108 @@
+:::::::::::::::::::::::::::::
+:: Asciidoctor_build_docx.bat
+:::::::::::::::::::::::::::::
+:: Sublime Build script (Windows version) that exports AsciiDoc to DOCX.
+::
+:: REQUIREMENTS:
+::
+::   1. This requires that ASCIIDOCTOR is installed on the system path.
+::      See https://docs.asciidoctor.org/asciidoctor/latest/install/.
+::
+::   2. This requires that PANDOC is installed on the system path.
+::      See https://pandoc.org/installing.html.
+::
+::   3. This assumes that there is a default program declared that can
+::      open DOCX files (e.g. Libre Office, see:
+::      https://www.libreoffice.org/download/download-libreoffice/).
+::
+:: To invoke this script from inside a *.sublime-build file, use:
+::
+::     Asciidoctor_build_docx.bat <file_path> <file_base_name> <file_extension>
+::
+:: where
+::     <file_path> is the folder containing the AsciiDoc source file, and
+
+::     <file_base_name> is the root name of the AsciiDoc source file (without
+::         the .adoc extension)
+::
+::     <file_extension> is the extension of the source file (adoc, asciidoc, txt, etc.)
+::
+:: There are three ways to specify a reference docx file for pandoc to use as a template:
+::
+::     1. If the AsciiDoc source file contains an attribute definition for
+::        :pandoc:, :pandoc-ref:, or :pandoc-reference:, and the value of that
+::        attribute exists as a file, then it will be used.
+::
+::        NOTE: There is nothing special about this being an attribute
+::              definition as far as AsciiDoc is concerned. This script
+::              searches the source file directly for it. Using attribute
+::              syntax just seems appropriate (as opposed to say something
+::              buried in a comment). If there are multiple :pandoc...:
+::              attributes defined in the file, only the last one will be used.
+::              This script will only find :pandoc...: attributes that are in
+::              the main source file, not in any included files.
+::
+::     2. If .\reference.docx exists, it will be used.
+::
+::     3. If .\.pandoc\reference.docx exists, it will be used.
+::
+::     4. Otherwise, no reference file will be used.
+::
+
+:: The second line of each of these removes any quotes (")
+set WORKING_PATH=%1
+set WORKING_PATH=%WORKING_PATH:"=%
+set BASE_NAME=%2
+set BASE_NAME=%BASE_NAME:"=%
+set EXTENSION=%3
+set EXTENSION=%EXTENSION:"=%
+
+set DATA_DIR=
+set DEST_FILE=%BASE_NAME%.docx
+set DOCBOOK_FILE=%BASE_NAME%.xml
+set SOURCE_FILE=%BASE_NAME%.%EXTENSION%
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::    Step 1: Parse the AsciiDoc file into a DocBook document
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+del /Q /F "%TEMP%\%2.*"
+del /Q /F "%WORKING_PATH%\%DEST_FILE%"
+
+call asciidoctor -b docbook -o "%TEMP%\%DOCBOOK_FILE%" "%SOURCE_FILE%"
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::   Step 2: See if there is a Pandoc reference DOCX (template) we can use
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+for /f "tokens=2" %%a in ('findstr /IR ":pandoc[-refnc]*: " "%SOURCE_FILE%"') do set PANDOC_REF_FILE=%%a
+if not exist "%PANDOC_REF_FILE%" (
+	set PANDOC_REF_FILE="reference.docx"
+)
+if not exist "%PANDOC_REF_FILE%" (
+	set PANDOC_REF_FILE=".pandoc\reference.docx"
+)
+
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::   Step 3: Use PanDoc to convert it from DocBook to DOCX format
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+if exist "%PANDOC_REF_FILE%" (
+	pandoc -f docbook  --reference-doc="%PANDOC_REF_FILE%" -t docx -o %TEMP%\%2.docx "%TEMP%\%DOCBOOK_FILE%"
+) else (
+	pandoc -f docbook -t docx -o "%TEMP%\%DEST_FILE%" "%TEMP%\%DOCBOOK_FILE%"
+)
+
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::   Step 4: Open the generated DOCX file (using the system-defined default
+::           program for .DOCX files)
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+if exist "%TEMP%\%2.docx" (
+	move /Y "%TEMP%\%DEST_FILE%" "%WORKING_PATH%"
+)
+if exist "%WORKING_PATH%\%DEST_FILE%" (
+	"%WORKING_PATH%\%DEST_FILE%"
+)
+


### PR DESCRIPTION
Fixes #8.

For HTML, this assumes that ASCIIDOCTOR is installed on the system path. For EPUB, this assumes that ASCIIDOCTOR-EPUB3 is also installed on the system path. For DOCX, this assumes that PANDOC is also installed on the system path.

NOTE: There is currently only a WINDOWS implementation for DOCX. (Someone just needs to translate the BAT file into SH scripts for Linux and Mac -- I'll open a pair of new issues for that.)