### PR TITLE
Now supports Goto Definition/Goto reference/Goto Symbol between block IDs (anchors/links). Also, tweaked the scope names for headings.

### DIFF
--- a/Color-Schemes/AsciiDoc Dark.sublime-color-scheme
+++ b/Color-Schemes/AsciiDoc Dark.sublime-color-scheme
@@ -258,7 +258,7 @@
         // =====================================================================
         {
             "name": "Section Titles",
-            "scope": "markup.heading.level",
+            "scope": "markup.heading",
             "background": "dodgerblue",
             "font_style": "bold",
         },

--- a/Preferences/Symbol-List-BlockIDs.tmPreferences
+++ b/Preferences/Symbol-List-BlockIDs.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Symbol List: Block IDs/Anchors</string>
+  <key>scope</key>
+  <string>text.asciidoc entity.name.label</string>
+  <key>settings</key>
+  <dict>
+    <!-- Local (i.e. current file): Ctrl+R -->
+    <key>showInSymbolList</key>
+    <integer>1</integer>
+    <!-- Global (i.e. project-wide): Ctrl+Shift+R -->
+    <key>showInIndexedSymbolList</key>
+    <integer>1</integer>
+  </dict>
+</dict>
+</plist>

--- a/Preferences/Symbol-List-Links.tmPreferences
+++ b/Preferences/Symbol-List-Links.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Symbol List: Document and Section Titles</string>
+  <key>scope</key>
+  <string>text.asciidoc variable.parameter.xref</string>
+  <key>settings</key>
+  <dict>
+    <!-- Goto Reference: Shift+F12 -->
+    <key>showInIndexedReferenceList</key>
+    <integer>1</integer>
+  </dict>
+</dict>
+</plist>

--- a/Syntaxes/Asciidoctor.sublime-syntax
+++ b/Syntaxes/Asciidoctor.sublime-syntax
@@ -14,6 +14,9 @@
 #   Copyright 2015 Jakub Jirutka <jakub@jirutka.cz> and the Asciidoctor Project.
 # ------------------------------------------------------------------------------
 
+# For the guidelines on what to scope names to use for what elements,
+# see: https://www.sublimetext.com/docs/scope_naming.html
+
 name:    AsciiDoc (Asciidoctor)
 comment: AsciiDoc Syntax
 version: 2
@@ -1353,7 +1356,7 @@ contexts:
       captures:
         0: meta.tag.blockid.asciidoc
         1: punctuation.definition.blockid.begin.asciidoc
-        2: markup.underline.blockid.id.asciidoc
+        2: entity.name.label.asciidoc
         3: punctuation.definition.blockid.end.asciidoc
 
 
@@ -1608,8 +1611,6 @@ contexts:
 #
 #       === Level 2 Section
 #
-# FIXME Do "markup.heading.level.1.asciidoc" etc. really need "level"? I think "markup.heading.1.asciidoc" should suffice, plus it's what I've seen color schemes expect. -- polyglot-jones
-# FIXME How about changing "markup.heading.level.0.asciidoc" "markup.title.asciidoc"? -- polyglot-jones
 
   section_titles:
     - include: title_level_5
@@ -1621,14 +1622,14 @@ contexts:
 
   title_level_0:
     - match: ^(=) (`?\w.*)$\n?
-      scope: markup.heading.level.0.asciidoc
+      scope: markup.heading.0.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_1:
     - match: ^(==) (`?\w.*)$\n?
-      scope: markup.heading.level.1.asciidoc
+      scope: markup.heading.1.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
@@ -1636,7 +1637,7 @@ contexts:
 
   title_level_2:
     - match: ^(===) (`?\w.*)$\n?
-      scope: markup.heading.level.2.asciidoc
+      scope: markup.heading.2.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
@@ -1644,21 +1645,21 @@ contexts:
 
   title_level_3:
     - match: ^(====) (`?\w.*)$\n?
-      scope: markup.heading.level.3.asciidoc
+      scope: markup.heading.3.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_4:
     - match: ^(=====) (`?\w.*)$\n?
-      scope: markup.heading.level.4.asciidoc
+      scope: markup.heading.4.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_5:
     - match: ^(======) (`?\w.*)$\n
-      scope: markup.heading.level.5.asciidoc
+      scope: markup.heading.5.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc

--- a/Tests/syntax_test_BlockID.asciidoc
+++ b/Tests/syntax_test_BlockID.asciidoc
@@ -18,7 +18,7 @@ A paragraph with a custom ID anchor.
 [[my_id]]
 //<-      meta.tag.blockid
 //^^^^^^^ meta.tag.blockid
-//^^^^^   markup.underline.blockid.id
+//^^^^^   entity.name.label.asciidoc
 //<-      punctuation.definition.blockid.begin
 //     ^^ punctuation.definition.blockid.end
 

--- a/Tests/syntax_test_Section-Titles.asciidoc
+++ b/Tests/syntax_test_Section-Titles.asciidoc
@@ -18,14 +18,14 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 = Document Title (Level 0)
 //<-                         text
-//<-                         markup.heading.level.0
+//<-                         markup.heading.0
 //<-                         punctuation.definition.heading
 //^^^^^^^^^^^^^^^^^^^^^^^^   entity.name.section
 //<-                        -entity.name.section
 
 
 == Level 1 Section Title
-// <-                        markup.heading.level.1
+// <-                        markup.heading.1
 // <-                        punctuation.definition.heading
 // ^^^^^^^^^^^^^^^^^^^^^     entity.name.section
 //<-                        -entity.name.section
@@ -33,7 +33,7 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 === Level 2 Section Title
-//<-                         markup.heading.level.2
+//<-                         markup.heading.2
 //<-                         punctuation.definition.heading
 //  ^^^^^^^^^^^^^^^^^^^^^    entity.name.section
 //<-                        -entity.name.section
@@ -41,7 +41,7 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ==== Level 3 Section Title
-//<-                         markup.heading.level.3
+//<-                         markup.heading.3
 //<-                         punctuation.definition.heading
 //   ^^^^^^^^^^^^^^^^^^^^^   entity.name.section
 //<-                        -entity.name.section
@@ -49,8 +49,8 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ===== Level 4 Section Title
-//<-                         markup.heading.level.4
-//^^^                        markup.heading.level.4
+//<-                         markup.heading.4
+//^^^                        markup.heading.4
 //<-                         punctuation.definition.heading
 //^^^                        punctuation.definition.heading
 //    ^^^^^^^^^^^^^^^^^^^^^  entity.name.section
@@ -59,8 +59,8 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ====== Level 5 Section Title
-//<-                          markup.heading.level.5
-//^^^^                        markup.heading.level.5
+//<-                          markup.heading.5
+//^^^^                        markup.heading.5
 //<-                          punctuation.definition.heading
 //^^^^                        punctuation.definition.heading
 //     ^^^^^^^^^^^^^^^^^^^^^  entity.name.section


### PR DESCRIPTION
1. Changed the block ID (anchor) scope from "markup.underline.blockid.id" to "entity.name.label" (per the syntax naming guidelines). Added a preference P-list for the block ID (entity.name.label) to be indexed and thus appear in the symbol list (for declaration goto targeting). Likewise, added a preference P-list for the block id within a link (variable.parameter.xref) to be indexed and thus appear in the symbol list (for reference goto targeting).

2. Removed the extraneous "level" from "markup.heading.level.1.asciidoc", "markup.heading.level.2.asciidoc", etc. to align with what the color schemes expect (e.g. the Monokai and Breakers schemes set one color for all "markup.heading" and a second color for "markup.heading.1" in particular, and Celeste also sets a third color for "markup.heading.2").