### PR TITLE
Syntax scope tweaks (heading.level, list.unordered, and list.ordered)

### DIFF
--- a/Asciidoctor.sublime-settings
+++ b/Asciidoctor.sublime-settings
@@ -1,5 +1,11 @@
 {
-  "color_scheme": "AsciiDoc Dark.sublime-color-scheme",
+  // We are refraining from forcing the color_scheme here because, for one
+  // thing, there is a bug in ST4. When ST4 loads, it tries to find this
+  // scheme in the "Color Scheme - Default" package (which it is not) and
+  // then hangs with an OS Error (instead of just skipping that location and
+  // searching on).
+
+  // "color_scheme": "AsciiDoc Dark.sublime-color-scheme",
 
   "indent_lists": true,
 

--- a/Color-Schemes/AsciiDoc Dark.sublime-color-scheme
+++ b/Color-Schemes/AsciiDoc Dark.sublime-color-scheme
@@ -213,7 +213,7 @@
         {
             "name": "Block Title",
             "scope": "markup.heading.block",
-            "foreground": "dodgerblue",
+            "background": "dodgerblue",
         },
         // =====================================================================
         // BLOCKS

--- a/Color-Schemes/AsciiDoc Dark.sublime-color-scheme
+++ b/Color-Schemes/AsciiDoc Dark.sublime-color-scheme
@@ -258,7 +258,7 @@
         // =====================================================================
         {
             "name": "Section Titles",
-            "scope": "markup.heading.level",
+            "scope": "markup.heading",
             "background": "dodgerblue",
             "font_style": "bold",
         },

--- a/Preferences/Symbol-List-BlockIDs.tmPreferences
+++ b/Preferences/Symbol-List-BlockIDs.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Symbol List: Block IDs/Anchors</string>
+  <key>scope</key>
+  <string>text.asciidoc entity.name.label</string>
+  <key>settings</key>
+  <dict>
+    <!-- Local (i.e. current file): Ctrl+R -->
+    <key>showInSymbolList</key>
+    <integer>1</integer>
+    <!-- Global (i.e. project-wide): Ctrl+Shift+R -->
+    <key>showInIndexedSymbolList</key>
+    <integer>1</integer>
+  </dict>
+</dict>
+</plist>

--- a/Preferences/Symbol-List-Links.tmPreferences
+++ b/Preferences/Symbol-List-Links.tmPreferences
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Symbol List: Document and Section Titles</string>
+  <key>scope</key>
+  <string>text.asciidoc variable.parameter.xref</string>
+  <key>settings</key>
+  <dict>
+    <!-- Goto Reference: Shift+F12 -->
+    <key>showInIndexedReferenceList</key>
+    <integer>1</integer>
+  </dict>
+</dict>
+</plist>

--- a/Syntaxes/Asciidoctor.sublime-syntax
+++ b/Syntaxes/Asciidoctor.sublime-syntax
@@ -1525,7 +1525,7 @@ contexts:
   ulist_item_marker:
     - match: ^\s*(\-|\*{1,5})\s+(?=\S)
       captures:
-        1: punctuation.definition.list_item.asciidoc
+        1: punctuation.definition.list.unordered.asciidoc
 
 # Markdwon scopes:
 #    text.html.markdown.gfm
@@ -1589,7 +1589,7 @@ contexts:
   olist_item_marker:
     - match: ^\s*(\.{1,5})\s+(?=\S)
       captures:
-        1: punctuation.definition.list_item.asciidoc
+        1: punctuation.definition.list.ordered.asciidoc
 
 
 # ==============================================================================
@@ -1622,14 +1622,14 @@ contexts:
 
   title_level_0:
     - match: ^(=) (`?\w.*)$\n?
-      scope: markup.heading.0.asciidoc
+      scope: markup.heading.level.0.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_1:
     - match: ^(==) (`?\w.*)$\n?
-      scope: markup.heading.1.asciidoc
+      scope: markup.heading.level.1.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
@@ -1637,7 +1637,7 @@ contexts:
 
   title_level_2:
     - match: ^(===) (`?\w.*)$\n?
-      scope: markup.heading.2.asciidoc
+      scope: markup.heading.level.2.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
@@ -1645,21 +1645,21 @@ contexts:
 
   title_level_3:
     - match: ^(====) (`?\w.*)$\n?
-      scope: markup.heading.3.asciidoc
+      scope: markup.heading.level.3.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_4:
     - match: ^(=====) (`?\w.*)$\n?
-      scope: markup.heading.4.asciidoc
+      scope: markup.heading.level.4.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_5:
     - match: ^(======) (`?\w.*)$\n
-      scope: markup.heading.5.asciidoc
+      scope: markup.heading.level.5.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc

--- a/Syntaxes/Asciidoctor.sublime-syntax
+++ b/Syntaxes/Asciidoctor.sublime-syntax
@@ -14,6 +14,9 @@
 #   Copyright 2015 Jakub Jirutka <jakub@jirutka.cz> and the Asciidoctor Project.
 # ------------------------------------------------------------------------------
 
+# For the guidelines on what to scope names to use for what elements,
+# see: https://www.sublimetext.com/docs/scope_naming.html
+
 name:    AsciiDoc (Asciidoctor)
 comment: AsciiDoc Syntax
 version: 2
@@ -1353,7 +1356,7 @@ contexts:
       captures:
         0: meta.tag.blockid.asciidoc
         1: punctuation.definition.blockid.begin.asciidoc
-        2: markup.underline.blockid.id.asciidoc
+        2: entity.name.label.asciidoc
         3: punctuation.definition.blockid.end.asciidoc
 
 
@@ -1608,8 +1611,6 @@ contexts:
 #
 #       === Level 2 Section
 #
-# FIXME Do "markup.heading.level.1.asciidoc" etc. really need "level"? I think "markup.heading.1.asciidoc" should suffice, plus it's what I've seen color schemes expect. -- polyglot-jones
-# FIXME How about changing "markup.heading.level.0.asciidoc" "markup.title.asciidoc"? -- polyglot-jones
 
   section_titles:
     - include: title_level_5
@@ -1621,14 +1622,14 @@ contexts:
 
   title_level_0:
     - match: ^(=) (`?\w.*)$\n?
-      scope: markup.heading.level.0.asciidoc
+      scope: markup.heading.0.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_1:
     - match: ^(==) (`?\w.*)$\n?
-      scope: markup.heading.level.1.asciidoc
+      scope: markup.heading.1.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
@@ -1636,7 +1637,7 @@ contexts:
 
   title_level_2:
     - match: ^(===) (`?\w.*)$\n?
-      scope: markup.heading.level.2.asciidoc
+      scope: markup.heading.2.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
@@ -1644,21 +1645,21 @@ contexts:
 
   title_level_3:
     - match: ^(====) (`?\w.*)$\n?
-      scope: markup.heading.level.3.asciidoc
+      scope: markup.heading.3.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_4:
     - match: ^(=====) (`?\w.*)$\n?
-      scope: markup.heading.level.4.asciidoc
+      scope: markup.heading.4.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc
 
   title_level_5:
     - match: ^(======) (`?\w.*)$\n
-      scope: markup.heading.level.5.asciidoc
+      scope: markup.heading.5.asciidoc
       captures:
         1: punctuation.definition.heading.asciidoc
         2: entity.name.section.asciidoc

--- a/Tests/lists/syntax_test_Ordered-Lists.asciidoc
+++ b/Tests/lists/syntax_test_Ordered-Lists.asciidoc
@@ -20,21 +20,21 @@ https://docs.asciidoctor.org/asciidoc/latest/lists/ordered/[Ordered Lists^]
 
 ======================================
 . Level 1
-//<-          punctuation.definition.list_item
-//^          -punctuation.definition.list_item
+//<-          punctuation.definition.list.ordered
+//^          -punctuation.definition.list.ordered
 .. Level 2
 ... Level 3
-//<-          punctuation.definition.list_item
-//^           punctuation.definition.list_item
-// ^         -punctuation.definition.list_item
+//<-          punctuation.definition.list.ordered
+//^           punctuation.definition.list.ordered
+// ^         -punctuation.definition.list.ordered
 .... Level 4
-//<-          punctuation.definition.list_item
-//^^          punctuation.definition.list_item
-//  ^        -punctuation.definition.list_item
+//<-          punctuation.definition.list.ordered
+//^^          punctuation.definition.list.ordered
+//  ^        -punctuation.definition.list.ordered
 ..... Level 5
-//<-          punctuation.definition.list_item
-//^^^         punctuation.definition.list_item
-//   ^       -punctuation.definition.list_item
+//<-          punctuation.definition.list.ordered
+//^^^         punctuation.definition.list.ordered
+//   ^       -punctuation.definition.list.ordered
 ======================================
 
 
@@ -42,20 +42,20 @@ https://docs.asciidoctor.org/asciidoc/latest/lists/ordered/[Ordered Lists^]
 == Loose Tests
 
   . Level 1
-//^        punctuation.definition.list_item
-// ^      -punctuation.definition.list_item
-//<-      -punctuation.definition.list_item
+//^        punctuation.definition.list.ordered
+// ^      -punctuation.definition.list.ordered
+//<-      -punctuation.definition.list.ordered
   .. Level 2
-//^^       punctuation.definition.list_item
-//  ^     -punctuation.definition.list_item
+//^^       punctuation.definition.list.ordered
+//  ^     -punctuation.definition.list.ordered
   ... Level 3
-//^^^      punctuation.definition.list_item
-//   ^    -punctuation.definition.list_item
+//^^^      punctuation.definition.list.ordered
+//   ^    -punctuation.definition.list.ordered
   .... Level 4
-//^^^^     punctuation.definition.list_item
-//    ^   -punctuation.definition.list_item
+//^^^^     punctuation.definition.list.ordered
+//    ^   -punctuation.definition.list.ordered
   ..... Level 5
-//^^^^^    punctuation.definition.list_item
-//     ^  -punctuation.definition.list_item
+//^^^^^    punctuation.definition.list.ordered
+//     ^  -punctuation.definition.list.ordered
 
 // EOF //

--- a/Tests/lists/syntax_test_Unordered-Lists.asciidoc
+++ b/Tests/lists/syntax_test_Unordered-Lists.asciidoc
@@ -23,21 +23,21 @@ https://docs.asciidoctor.org/asciidoc/latest/lists/unordered/[Unordered Lists^]
 
 ======================================
 * Level 1
-//<-          punctuation.definition.list_item
-//^          -punctuation.definition.list_item
+//<-          punctuation.definition.list.unordered
+//^          -punctuation.definition.list.unordered
 ** Level 2
 *** Level 3
-//<-          punctuation.definition.list_item
-//^           punctuation.definition.list_item
-// ^         -punctuation.definition.list_item
+//<-          punctuation.definition.list.unordered
+//^           punctuation.definition.list.unordered
+// ^         -punctuation.definition.list.unordered
 **** Level 4
-//<-          punctuation.definition.list_item
-//^^          punctuation.definition.list_item
-//  ^        -punctuation.definition.list_item
+//<-          punctuation.definition.list.unordered
+//^^          punctuation.definition.list.unordered
+//  ^        -punctuation.definition.list.unordered
 ***** Level 5
-//<-          punctuation.definition.list_item
-//^^^         punctuation.definition.list_item
-//   ^       -punctuation.definition.list_item
+//<-          punctuation.definition.list.unordered
+//^^^         punctuation.definition.list.unordered
+//   ^       -punctuation.definition.list.unordered
 ======================================
 
 
@@ -61,14 +61,14 @@ But a change in marker from hyphen to asterisk (or the inverse) will create a ne
 
 ======================================
 * Level 1
-//<-          punctuation.definition.list_item
-//^          -punctuation.definition.list_item
+//<-          punctuation.definition.list.unordered
+//^          -punctuation.definition.list.unordered
 - Level 2
-//<-          punctuation.definition.list_item
-//^          -punctuation.definition.list_item
+//<-          punctuation.definition.list.unordered
+//^          -punctuation.definition.list.unordered
 * Level 1
-//<-          punctuation.definition.list_item
-//^          -punctuation.definition.list_item
+//<-          punctuation.definition.list.unordered
+//^          -punctuation.definition.list.unordered
 ======================================
 
 
@@ -76,24 +76,24 @@ But a change in marker from hyphen to asterisk (or the inverse) will create a ne
 == Loose Tests
 
   - Level 1 (hyphen marker)
-//^        punctuation.definition.list_item
-// ^      -punctuation.definition.list_item
-//<-      -punctuation.definition.list_item
+//^        punctuation.definition.list.unordered
+// ^      -punctuation.definition.list.unordered
+//<-      -punctuation.definition.list.unordered
   * Level 2
-//^        punctuation.definition.list_item
-// ^      -punctuation.definition.list_item
-//<-      -punctuation.definition.list_item
+//^        punctuation.definition.list.unordered
+// ^      -punctuation.definition.list.unordered
+//<-      -punctuation.definition.list.unordered
   ** Level 3
-//^^       punctuation.definition.list_item
-//  ^     -punctuation.definition.list_item
+//^^       punctuation.definition.list.unordered
+//  ^     -punctuation.definition.list.unordered
   *** Level 4
-//^^^      punctuation.definition.list_item
-//   ^    -punctuation.definition.list_item
+//^^^      punctuation.definition.list.unordered
+//   ^    -punctuation.definition.list.unordered
   **** Level 5
-//^^^^     punctuation.definition.list_item
-//    ^   -punctuation.definition.list_item
+//^^^^     punctuation.definition.list.unordered
+//    ^   -punctuation.definition.list.unordered
   ***** Level 6
-//^^^^^    punctuation.definition.list_item
-//     ^  -punctuation.definition.list_item
+//^^^^^    punctuation.definition.list.unordered
+//     ^  -punctuation.definition.list.unordered
 
 // EOF //

--- a/Tests/syntax_test_BlockID.asciidoc
+++ b/Tests/syntax_test_BlockID.asciidoc
@@ -18,7 +18,7 @@ A paragraph with a custom ID anchor.
 [[my_id]]
 //<-      meta.tag.blockid
 //^^^^^^^ meta.tag.blockid
-//^^^^^   markup.underline.blockid.id
+//^^^^^   entity.name.label.asciidoc
 //<-      punctuation.definition.blockid.begin
 //     ^^ punctuation.definition.blockid.end
 

--- a/Tests/syntax_test_Section-Titles.asciidoc
+++ b/Tests/syntax_test_Section-Titles.asciidoc
@@ -10,7 +10,7 @@
 This file tests standard AsciiDoc syntax for Section Titles (Headings 1-5) using two to six `=` signs, and one for Part Titles in books or for the Document Title.
 
 The number of equal signs matches the heading level in the HTML output.
-For example, Section Level 1 becomes an H2 heading.
+For example, Section Level 1 becomes an H2 heading.level.
 
 AsciiDoc Documentation reference:
 https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section Titles and Levels^]
@@ -18,14 +18,14 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 = Document Title (Level 0)
 //<-                         text
-//<-                         markup.heading.0
+//<-                         markup.heading.level.0
 //<-                         punctuation.definition.heading
 //^^^^^^^^^^^^^^^^^^^^^^^^   entity.name.section
 //<-                        -entity.name.section
 
 
 == Level 1 Section Title
-// <-                        markup.heading.1
+// <-                        markup.heading.level.1
 // <-                        punctuation.definition.heading
 // ^^^^^^^^^^^^^^^^^^^^^     entity.name.section
 //<-                        -entity.name.section
@@ -33,7 +33,7 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 === Level 2 Section Title
-//<-                         markup.heading.2
+//<-                         markup.heading.level.2
 //<-                         punctuation.definition.heading
 //  ^^^^^^^^^^^^^^^^^^^^^    entity.name.section
 //<-                        -entity.name.section
@@ -41,7 +41,7 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ==== Level 3 Section Title
-//<-                         markup.heading.3
+//<-                         markup.heading.level.3
 //<-                         punctuation.definition.heading
 //   ^^^^^^^^^^^^^^^^^^^^^   entity.name.section
 //<-                        -entity.name.section
@@ -49,8 +49,8 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ===== Level 4 Section Title
-//<-                         markup.heading.4
-//^^^                        markup.heading.4
+//<-                         markup.heading.level.4
+//^^^                        markup.heading.level.4
 //<-                         punctuation.definition.heading
 //^^^                        punctuation.definition.heading
 //    ^^^^^^^^^^^^^^^^^^^^^  entity.name.section
@@ -59,8 +59,8 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ====== Level 5 Section Title
-//<-                          markup.heading.5
-//^^^^                        markup.heading.5
+//<-                          markup.heading.level.5
+//^^^^                        markup.heading.level.5
 //<-                          punctuation.definition.heading
 //^^^^                        punctuation.definition.heading
 //     ^^^^^^^^^^^^^^^^^^^^^  entity.name.section

--- a/Tests/syntax_test_Section-Titles.asciidoc
+++ b/Tests/syntax_test_Section-Titles.asciidoc
@@ -18,14 +18,14 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 = Document Title (Level 0)
 //<-                         text
-//<-                         markup.heading.level.0
+//<-                         markup.heading.0
 //<-                         punctuation.definition.heading
 //^^^^^^^^^^^^^^^^^^^^^^^^   entity.name.section
 //<-                        -entity.name.section
 
 
 == Level 1 Section Title
-// <-                        markup.heading.level.1
+// <-                        markup.heading.1
 // <-                        punctuation.definition.heading
 // ^^^^^^^^^^^^^^^^^^^^^     entity.name.section
 //<-                        -entity.name.section
@@ -33,7 +33,7 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 === Level 2 Section Title
-//<-                         markup.heading.level.2
+//<-                         markup.heading.2
 //<-                         punctuation.definition.heading
 //  ^^^^^^^^^^^^^^^^^^^^^    entity.name.section
 //<-                        -entity.name.section
@@ -41,7 +41,7 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ==== Level 3 Section Title
-//<-                         markup.heading.level.3
+//<-                         markup.heading.3
 //<-                         punctuation.definition.heading
 //   ^^^^^^^^^^^^^^^^^^^^^   entity.name.section
 //<-                        -entity.name.section
@@ -49,8 +49,8 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ===== Level 4 Section Title
-//<-                         markup.heading.level.4
-//^^^                        markup.heading.level.4
+//<-                         markup.heading.4
+//^^^                        markup.heading.4
 //<-                         punctuation.definition.heading
 //^^^                        punctuation.definition.heading
 //    ^^^^^^^^^^^^^^^^^^^^^  entity.name.section
@@ -59,8 +59,8 @@ https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/[Section
 
 
 ====== Level 5 Section Title
-//<-                          markup.heading.level.5
-//^^^^                        markup.heading.level.5
+//<-                          markup.heading.5
+//^^^^                        markup.heading.5
 //<-                          punctuation.definition.heading
 //^^^^                        punctuation.definition.heading
 //     ^^^^^^^^^^^^^^^^^^^^^  entity.name.section

--- a/docs-src/color-schemes.adoc
+++ b/docs-src/color-schemes.adoc
@@ -1,0 +1,197 @@
+= Color Schemes
+
+== Using ST4's Default Color Schemes
+
+ST4 ships with five default colors schemes: "`Breakers,`" "`Celeste,`" "`Mariana,`" "`Monokai,`" and "`Sixteen.`"
+
+They all have minimal support for colorizing markup files, in general, but none of them are nuanced in the particulars imparted by our AsciiDoc syntax specification, since our specification did not exist at the time that these schemes were created.
+Nonetheless, a main objective of our syntax specification is to conform to the naming conventions expected by these default color schemes, so that they will continue to provide that minimal, generic support when it comes to AsciiDoc files in particular.
+
+=== Basic Scope Names
+
+Here is a cumulative list of the scope names that are recognized by the default color schemes; however, not all of these scopes are recognized by all of the schemes.
+For example, all of them colorize `comment`, but not all of them colorize the corresponding `punctuation.definition.comment` (by the choice of that color scheme's designer).
+
+For another example, all of them colorize `invalid.illegal` and `invalid.deprecated`, but they do it differently.
+Some will colorize the two specifically by name, while others first colorize `invalid` in general, and then specify a different color for `invalid.deprecated` qualifier in particular -- which, by the way, is the recommended way of doing it.
+
+NOTE: Anyone who sets out to create a fresh color scheme that does support the AsciiDoc nuances, should also ensure that the basics are covered first.
+
+To understand the semantics of these scope names, see: https://www.sublimetext.com/docs/scope_naming.html[]
+
+*comment*:
+
+(`comment` has no qualifiers.)
+
+*constant*:
+
+* `constant.character`
+* `constant.character.escape`
+* `constant.language`
+* `constant.numeric`
+* `constant.numeric.line-number.find-in-files`
+* `constant.numeric.line-number.match`
+* `constant.other`
+* `constant.other.color`
+* `constant.other.language-name`
+
+*diff*:
+
+* `diff.deleted`
+* `diff.deleted.char`
+* `diff.inserted`
+* `diff.inserted.char`
+
+*entity*:
+
+* `entity.name`
+* `entity.name.filename`
+* `entity.name.function`
+* `entity.name.label`
+* `entity.name.section`
+* `entity.name.tag`
+* `entity.name.tag.yaml`
+* `entity.other.attribute-name`
+* `entity.other.attribute-name.id`
+* `entity.other.inherited-class`
+* `entity.other.pseudo-class`
+
+*invalid*:
+
+* `invalid.deprecated`
+* `invalid.illegal`
+
+*keyword*:
+
+* `keyword.declaration`
+* `keyword.operator`
+* `keyword.operator.word`
+
+*markup*:
+
+* `markup.bold`
+* `markup.changed`
+* `markup.deleted`
+* `markup.heading`
+* `markup.heading.1`
+* `markup.heading.2`
+* `markup.inserted`
+* `markup.italic`
+* `markup.list`
+* `markup.list.numbered`
+* `markup.list.numbered.bullet`
+* `markup.list.unnumbered.bullet`
+* `markup.quote`
+* `markup.raw`
+* `markup.raw.inline`
+* `markup.underline`
+* `markup.underline.link`
+
+*match*:
+
+(`match` has no qualifiers.)
+
+*message*:
+
+* `message.error`
+
+*meta*:
+
+* `meta.diff`
+* `meta.diff.header`
+* `meta.function-call`
+* `meta.structure.dictionary.json`
+* `meta.table.header`
+
+*punctuation*:
+
+* `punctuation.accessor`
+* `punctuation.definition`
+* `punctuation.definition.annotation`
+* `punctuation.definition.blockquote`
+* `punctuation.definition.bold`
+* `punctuation.definition.comment`
+* `punctuation.definition.constant`
+* `punctuation.definition.heading`
+* `punctuation.definition.image`
+* `punctuation.definition.italic`
+* `punctuation.definition.link`
+* `punctuation.definition.list_item`
+* `punctuation.definition.metadata`
+* `punctuation.definition.numeric.base`
+* `punctuation.definition.raw`
+* `punctuation.definition.string`
+* `punctuation.definition.thematic-break`
+* `punctuation.section`
+* `punctuation.section.embedded`
+* `punctuation.section.table-header`
+* `punctuation.separator`
+* `punctuation.separator.table-cell`
+* `punctuation.terminator`
+
+*source*:
+
+* `source.c`
+* `source.c++`
+* `source.css`
+* `source.objc`
+* `source.objc++`
+* `source.ruby`
+* `source.yaml`
+
+*storage*:
+
+* `storage.type`
+* `storage.type.numeric`
+
+*string*:
+
+* `string.other.link`
+* `string.quoted.double.json`
+* `string.regexp`
+* `string.unquoted`
+* `string.unquoted.yaml`
+
+*support*:
+
+* `support.class`
+* `support.class.builtin`
+* `support.class.dollar.only.js`
+* `support.constant`
+* `support.function`
+* `support.function.builtin`
+* `support.macro`
+* `support.other.variable`
+* `support.type`
+* `support.type.property-name`
+* `support.type.sys-types`
+* `support.type.vendor-prefix`
+
+*text*:
+
+(`text` has no qualifiers.)
+
+*variable*:
+
+* `variable.annotation`
+* `variable.function`
+* `variable.interpolation`
+* `variable.language`
+* `variable.member`
+* `variable.other.dollar.only.js`
+* `variable.other.object.dollar.only.js`
+* `variable.parameter`
+* `variable.type.dollar.only.js`
+
+
+== AsciiDoc-Specific Color Schemes
+
+This package ships with a dedicated color scheme ("`AsciiDoc Dark`") which takes full advantage of this package's AsciiDoc syntax specification.
+For example, the "`Molokai`", "`Breakers`", and "`Celeste`" color schemes that ship with ST4 do not bother to highlight the list bullets, nor the fences around tables, nor any of the markers that start and end various blocks (examples, sidebar, etc.).
+
+To enable the "`AsciiDoc Dark`" scheme, or pick any other color scheme of your choice, simply pull down the "`Preferences`" menu and use "`Select Color Scheme...`".
+
+IMPORTANT: Since this package is still very much under development, it is important that collaborators use an AsciiDoc-specific color scheme in order to appreciate/experience/test the syntax highlighting nuances.
+Many elements of the AsciiDoc syntax rely on (fine-grained) scope names which are peculiar to AsciiDoc, and very unlikely to be covered by general-purpose color schemes designed for programming languages or lightweight markup syntaxes (like Markdown, reST, etc.).
+
+

--- a/docs-src/features.adoc
+++ b/docs-src/features.adoc
@@ -15,24 +15,6 @@ The following file extensions are automatically recognized as AsciiDoc files:
 * `.asciidoc`
 
 
-== Color Schemes
-
-The package ships with a dedicated color scheme (AsciiDoc Dark) which is enable by default in `Asciidoctor.sublime-settings`:
-
-[source,json]
--------------------------------------------------------
-{
-  "color_scheme": "AsciiDoc Dark.sublime-color-scheme",
--------------------------------------------------------
-
-You can always override this setting and enforce a color scheme of your choice by creating your own `Asciidoctor.sublime-settings` in the `Packages/User` directory.
-
-The reason I'm currently enforcing the package default scheme is because the package is still under development, and this color scheme reflects the overall direction of my efforts in term of what I believe should be visually highlighted while working with the AsciiDoc syntax.
-Therefore, I would like all collaborators to the project to appreciate the native package scheme and its "`flavor,`" so to speak.
-
-Many elements of the AsciiDoc syntax rely on scopes names which are peculiar to AsciiDoc, and very unlikely to be covered by general purpose color schemes designed for programming languages or lightweight markup syntaxes (like Markdown, reST, etc.).
-
-
 == Snippets
 
 The following table lists the package snippets and their features.

--- a/docs-src/index.asciidoc
+++ b/docs-src/index.asciidoc
@@ -40,6 +40,9 @@ package.
 
 
 include::intro.adoc[]
+
 include::features.adoc[]
+
+include::color-schemes.adoc[]
 
 // EOF //

--- a/docs/index.html
+++ b/docs/index.html
@@ -434,184 +434,6 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 @media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-<style>
-pre.rouge table td { padding: 5px; }
-pre.rouge table pre { margin: 0; }
-pre.rouge {
-  color: #faf6e4;
-  background-color: #122b3b;
-}
-pre.rouge .gl {
-  color: #dee5e7;
-  background-color: #4e5d62;
-}
-pre.rouge .gp {
-  color: #a8e1fe;
-  font-weight: bold;
-}
-pre.rouge .c, pre.rouge .ch, pre.rouge .cd, pre.rouge .cm, pre.rouge .cpf, pre.rouge .c1, pre.rouge .cs {
-  color: #6c8b9f;
-  font-style: italic;
-}
-pre.rouge .cp {
-  color: #b2fd6d;
-  font-weight: bold;
-}
-pre.rouge .err {
-  color: #fefeec;
-  background-color: #cc0000;
-}
-pre.rouge .gr {
-  color: #cc0000;
-  font-weight: bold;
-  font-style: italic;
-}
-pre.rouge .k, pre.rouge .kd, pre.rouge .kv {
-  color: #f6dd62;
-  font-weight: bold;
-}
-pre.rouge .o, pre.rouge .ow {
-  color: #4df4ff;
-  font-weight: bold;
-}
-pre.rouge .p, pre.rouge .pi {
-  color: #4df4ff;
-}
-pre.rouge .gd {
-  color: #cc0000;
-}
-pre.rouge .gi {
-  color: #b2fd6d;
-}
-pre.rouge .ge {
-  font-style: italic;
-}
-pre.rouge .gs {
-  font-weight: bold;
-}
-pre.rouge .gt {
-  color: #dee5e7;
-  background-color: #4e5d62;
-}
-pre.rouge .kc {
-  color: #f696db;
-  font-weight: bold;
-}
-pre.rouge .kn {
-  color: #ffb000;
-  font-weight: bold;
-}
-pre.rouge .kp {
-  color: #ffb000;
-  font-weight: bold;
-}
-pre.rouge .kr {
-  color: #ffb000;
-  font-weight: bold;
-}
-pre.rouge .gh {
-  color: #ffb000;
-  font-weight: bold;
-}
-pre.rouge .gu {
-  color: #ffb000;
-  font-weight: bold;
-}
-pre.rouge .kt {
-  color: #b2fd6d;
-  font-weight: bold;
-}
-pre.rouge .no {
-  color: #b2fd6d;
-  font-weight: bold;
-}
-pre.rouge .nc {
-  color: #b2fd6d;
-  font-weight: bold;
-}
-pre.rouge .nd {
-  color: #b2fd6d;
-  font-weight: bold;
-}
-pre.rouge .nn {
-  color: #b2fd6d;
-  font-weight: bold;
-}
-pre.rouge .bp {
-  color: #b2fd6d;
-  font-weight: bold;
-}
-pre.rouge .ne {
-  color: #b2fd6d;
-  font-weight: bold;
-}
-pre.rouge .nl {
-  color: #ffb000;
-  font-weight: bold;
-}
-pre.rouge .nt {
-  color: #ffb000;
-  font-weight: bold;
-}
-pre.rouge .m, pre.rouge .mb, pre.rouge .mf, pre.rouge .mh, pre.rouge .mi, pre.rouge .il, pre.rouge .mo, pre.rouge .mx {
-  color: #f696db;
-  font-weight: bold;
-}
-pre.rouge .ld {
-  color: #f696db;
-  font-weight: bold;
-}
-pre.rouge .ss {
-  color: #f696db;
-  font-weight: bold;
-}
-pre.rouge .s, pre.rouge .sb, pre.rouge .dl, pre.rouge .sd, pre.rouge .s2, pre.rouge .sh, pre.rouge .sx, pre.rouge .sr, pre.rouge .s1 {
-  color: #fff0a6;
-  font-weight: bold;
-}
-pre.rouge .sa {
-  color: #f6dd62;
-  font-weight: bold;
-}
-pre.rouge .se {
-  color: #4df4ff;
-  font-weight: bold;
-}
-pre.rouge .sc {
-  color: #4df4ff;
-  font-weight: bold;
-}
-pre.rouge .si {
-  color: #4df4ff;
-  font-weight: bold;
-}
-pre.rouge .nb {
-  font-weight: bold;
-}
-pre.rouge .ni {
-  color: #999999;
-  font-weight: bold;
-}
-pre.rouge .w {
-  color: #BBBBBB;
-}
-pre.rouge .go {
-  color: #BBBBBB;
-}
-pre.rouge .nf, pre.rouge .fm {
-  color: #a8e1fe;
-}
-pre.rouge .py {
-  color: #a8e1fe;
-}
-pre.rouge .na {
-  color: #a8e1fe;
-}
-pre.rouge .nv, pre.rouge .vc, pre.rouge .vg, pre.rouge .vi, pre.rouge .vm {
-  color: #a8e1fe;
-  font-weight: bold;
-}
-</style>
 </head>
 <body class="book toc2 toc-left">
 <div id="header">
@@ -630,7 +452,6 @@ pre.rouge .nv, pre.rouge .vc, pre.rouge .vg, pre.rouge .vi, pre.rouge .vm {
 <li><a href="#package_features">Package Features</a>
 <ul class="sectlevel1">
 <li><a href="#associated_file_extensions">Associated File Extensions</a></li>
-<li><a href="#color_schemes">Color Schemes</a></li>
 <li><a href="#snippets">Snippets</a></li>
 <li><a href="#completions">Completions</a></li>
 <li><a href="#keymap_details">Keymap Details</a>
@@ -652,6 +473,12 @@ pre.rouge .nv, pre.rouge .vc, pre.rouge .vg, pre.rouge .vi, pre.rouge .vm {
 <li><a href="#usage_tips">Usage Tips</a></li>
 </ul>
 </li>
+<li><a href="#using_st4s_default_color_schemes">Using ST4&#8217;s Default Color Schemes</a>
+<ul class="sectlevel2">
+<li><a href="#basic_scope_names">Basic Scope Names</a></li>
+</ul>
+</li>
+<li><a href="#asciidoc_specific_color_schemes">AsciiDoc-Specific Color Schemes</a></li>
 </ul>
 </li>
 </ul>
@@ -736,30 +563,6 @@ Once the package will reach v1.0.0, braking changes will occur rarely.</p>
 <p><code>.asciidoc</code></p>
 </li>
 </ul>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="color_schemes"><a class="anchor" href="#color_schemes"></a>Color Schemes</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>The package ships with a dedicated color scheme (AsciiDoc Dark) which is enable by default in <code>Asciidoctor.sublime-settings</code>:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="rouge highlight"><code data-lang="json"><span class="p">{</span><span class="w">
-  </span><span class="nl">"color_scheme"</span><span class="p">:</span><span class="w"> </span><span class="s2">"AsciiDoc Dark.sublime-color-scheme"</span><span class="p">,</span></code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>You can always override this setting and enforce a color scheme of your choice by creating your own <code>Asciidoctor.sublime-settings</code> in the <code>Packages/User</code> directory.</p>
-</div>
-<div class="paragraph">
-<p>The reason I&#8217;m currently enforcing the package default scheme is because the package is still under development, and this color scheme reflects the overall direction of my efforts in term of what I believe should be visually highlighted while working with the AsciiDoc syntax.
-Therefore, I would like all collaborators to the project to appreciate the native package scheme and its &#8220;flavor,&#8221; so to speak.</p>
-</div>
-<div class="paragraph">
-<p>Many elements of the AsciiDoc syntax rely on scopes names which are peculiar to AsciiDoc, and very unlikely to be covered by general purpose color schemes designed for programming languages or lightweight markup syntaxes (like Markdown, reST, etc.).</p>
 </div>
 </div>
 </div>
@@ -1186,8 +989,518 @@ Also, this script will only find <code>:pandoc&#8230;&#8203;:</code> attributes 
 <div class="paragraph">
 <p>You can leave an <strong>HMTL</strong> file open in your browser while you regenerate it.
 Then, just refresh the page with <kbd>F5</kbd>.
-For <strong>EPUB</strong> and <strong>DOCX</strong> files, however, you must close them before they can be regenerated.</p>
+For <strong>EPUB</strong> and <strong>DOCX</strong> files, however, you must close them before they can be regenerated.
+= Color Schemes</p>
 </div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="using_st4s_default_color_schemes"><a class="anchor" href="#using_st4s_default_color_schemes"></a>Using ST4&#8217;s Default Color Schemes</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>ST4 ships with five default colors schemes: &#8220;Breakers,&#8221; &#8220;Celeste,&#8221; &#8220;Mariana,&#8221; &#8220;Monokai,&#8221; and &#8220;Sixteen.&#8221;</p>
+</div>
+<div class="paragraph">
+<p>They all have minimal support for colorizing markup files, in general, but none of them are nuanced in the particulars imparted by our AsciiDoc syntax specification, since our specification did not exist at the time that these schemes were created.
+Nonetheless, a main objective of our syntax specification is to conform to the naming conventions expected by these default color schemes, so that they will continue to provide that minimal, generic support when it comes to AsciiDoc files in particular.</p>
+</div>
+<div class="sect2">
+<h3 id="basic_scope_names"><a class="anchor" href="#basic_scope_names"></a>Basic Scope Names</h3>
+<div class="paragraph">
+<p>Here is a cumulative list of the scope names that are recognized by the default color schemes; however, not all of these scopes are recognized by all of the schemes.
+For example, all of them colorize <code>comment</code>, but not all of them colorize the corresponding <code>punctuation.definition.comment</code> (by the choice of that color scheme&#8217;s designer).</p>
+</div>
+<div class="paragraph">
+<p>For another example, all of them colorize <code>invalid.illegal</code> and <code>invalid.deprecated</code>, but they do it differently.
+Some will colorize the two specifically by name, while others first colorize <code>invalid</code> in general, and then specify a different color for <code>invalid.deprecated</code> qualifier in particular&#8201;&#8212;&#8201;which, by the way, is the recommended way of doing it.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+Anyone who sets out to create a fresh color scheme that does support the AsciiDoc nuances, should also ensure that the basics are covered first.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>To understand the semantics of these scope names, see: <a href="https://www.sublimetext.com/docs/scope_naming.html" class="bare">https://www.sublimetext.com/docs/scope_naming.html</a></p>
+</div>
+<div class="paragraph">
+<p><strong>comment</strong>:</p>
+</div>
+<div class="paragraph">
+<p>(<code>comment</code> has no qualifiers.)</p>
+</div>
+<div class="paragraph">
+<p><strong>constant</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>constant.character</code></p>
+</li>
+<li>
+<p><code>constant.character.escape</code></p>
+</li>
+<li>
+<p><code>constant.language</code></p>
+</li>
+<li>
+<p><code>constant.numeric</code></p>
+</li>
+<li>
+<p><code>constant.numeric.line-number.find-in-files</code></p>
+</li>
+<li>
+<p><code>constant.numeric.line-number.match</code></p>
+</li>
+<li>
+<p><code>constant.other</code></p>
+</li>
+<li>
+<p><code>constant.other.color</code></p>
+</li>
+<li>
+<p><code>constant.other.language-name</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>diff</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>diff.deleted</code></p>
+</li>
+<li>
+<p><code>diff.deleted.char</code></p>
+</li>
+<li>
+<p><code>diff.inserted</code></p>
+</li>
+<li>
+<p><code>diff.inserted.char</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>entity</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>entity.name</code></p>
+</li>
+<li>
+<p><code>entity.name.filename</code></p>
+</li>
+<li>
+<p><code>entity.name.function</code></p>
+</li>
+<li>
+<p><code>entity.name.label</code></p>
+</li>
+<li>
+<p><code>entity.name.section</code></p>
+</li>
+<li>
+<p><code>entity.name.tag</code></p>
+</li>
+<li>
+<p><code>entity.name.tag.yaml</code></p>
+</li>
+<li>
+<p><code>entity.other.attribute-name</code></p>
+</li>
+<li>
+<p><code>entity.other.attribute-name.id</code></p>
+</li>
+<li>
+<p><code>entity.other.inherited-class</code></p>
+</li>
+<li>
+<p><code>entity.other.pseudo-class</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>invalid</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>invalid.deprecated</code></p>
+</li>
+<li>
+<p><code>invalid.illegal</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>keyword</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>keyword.declaration</code></p>
+</li>
+<li>
+<p><code>keyword.operator</code></p>
+</li>
+<li>
+<p><code>keyword.operator.word</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>markup</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>markup.bold</code></p>
+</li>
+<li>
+<p><code>markup.changed</code></p>
+</li>
+<li>
+<p><code>markup.deleted</code></p>
+</li>
+<li>
+<p><code>markup.heading</code></p>
+</li>
+<li>
+<p><code>markup.heading.1</code></p>
+</li>
+<li>
+<p><code>markup.heading.2</code></p>
+</li>
+<li>
+<p><code>markup.inserted</code></p>
+</li>
+<li>
+<p><code>markup.italic</code></p>
+</li>
+<li>
+<p><code>markup.list</code></p>
+</li>
+<li>
+<p><code>markup.list.numbered</code></p>
+</li>
+<li>
+<p><code>markup.list.numbered.bullet</code></p>
+</li>
+<li>
+<p><code>markup.list.unnumbered.bullet</code></p>
+</li>
+<li>
+<p><code>markup.quote</code></p>
+</li>
+<li>
+<p><code>markup.raw</code></p>
+</li>
+<li>
+<p><code>markup.raw.inline</code></p>
+</li>
+<li>
+<p><code>markup.underline</code></p>
+</li>
+<li>
+<p><code>markup.underline.link</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>match</strong>:</p>
+</div>
+<div class="paragraph">
+<p>(<code>match</code> has no qualifiers.)</p>
+</div>
+<div class="paragraph">
+<p><strong>message</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>message.error</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>meta</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>meta.diff</code></p>
+</li>
+<li>
+<p><code>meta.diff.header</code></p>
+</li>
+<li>
+<p><code>meta.function-call</code></p>
+</li>
+<li>
+<p><code>meta.structure.dictionary.json</code></p>
+</li>
+<li>
+<p><code>meta.table.header</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>punctuation</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>punctuation.accessor</code></p>
+</li>
+<li>
+<p><code>punctuation.definition</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.annotation</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.blockquote</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.bold</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.comment</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.constant</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.heading</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.image</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.italic</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.link</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.list_item</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.metadata</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.numeric.base</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.raw</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.string</code></p>
+</li>
+<li>
+<p><code>punctuation.definition.thematic-break</code></p>
+</li>
+<li>
+<p><code>punctuation.section</code></p>
+</li>
+<li>
+<p><code>punctuation.section.embedded</code></p>
+</li>
+<li>
+<p><code>punctuation.section.table-header</code></p>
+</li>
+<li>
+<p><code>punctuation.separator</code></p>
+</li>
+<li>
+<p><code>punctuation.separator.table-cell</code></p>
+</li>
+<li>
+<p><code>punctuation.terminator</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>source</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>source.c</code></p>
+</li>
+<li>
+<p><code>source.c++</code></p>
+</li>
+<li>
+<p><code>source.css</code></p>
+</li>
+<li>
+<p><code>source.objc</code></p>
+</li>
+<li>
+<p><code>source.objc++</code></p>
+</li>
+<li>
+<p><code>source.ruby</code></p>
+</li>
+<li>
+<p><code>source.yaml</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>storage</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>storage.type</code></p>
+</li>
+<li>
+<p><code>storage.type.numeric</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>string</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>string.other.link</code></p>
+</li>
+<li>
+<p><code>string.quoted.double.json</code></p>
+</li>
+<li>
+<p><code>string.regexp</code></p>
+</li>
+<li>
+<p><code>string.unquoted</code></p>
+</li>
+<li>
+<p><code>string.unquoted.yaml</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>support</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>support.class</code></p>
+</li>
+<li>
+<p><code>support.class.builtin</code></p>
+</li>
+<li>
+<p><code>support.class.dollar.only.js</code></p>
+</li>
+<li>
+<p><code>support.constant</code></p>
+</li>
+<li>
+<p><code>support.function</code></p>
+</li>
+<li>
+<p><code>support.function.builtin</code></p>
+</li>
+<li>
+<p><code>support.macro</code></p>
+</li>
+<li>
+<p><code>support.other.variable</code></p>
+</li>
+<li>
+<p><code>support.type</code></p>
+</li>
+<li>
+<p><code>support.type.property-name</code></p>
+</li>
+<li>
+<p><code>support.type.sys-types</code></p>
+</li>
+<li>
+<p><code>support.type.vendor-prefix</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>text</strong>:</p>
+</div>
+<div class="paragraph">
+<p>(<code>text</code> has no qualifiers.)</p>
+</div>
+<div class="paragraph">
+<p><strong>variable</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>variable.annotation</code></p>
+</li>
+<li>
+<p><code>variable.function</code></p>
+</li>
+<li>
+<p><code>variable.interpolation</code></p>
+</li>
+<li>
+<p><code>variable.language</code></p>
+</li>
+<li>
+<p><code>variable.member</code></p>
+</li>
+<li>
+<p><code>variable.other.dollar.only.js</code></p>
+</li>
+<li>
+<p><code>variable.other.object.dollar.only.js</code></p>
+</li>
+<li>
+<p><code>variable.parameter</code></p>
+</li>
+<li>
+<p><code>variable.type.dollar.only.js</code></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="asciidoc_specific_color_schemes"><a class="anchor" href="#asciidoc_specific_color_schemes"></a>AsciiDoc-Specific Color Schemes</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This package ships with a dedicated color scheme (&#8220;AsciiDoc Dark&#8221;) which takes full advantage of this package&#8217;s AsciiDoc syntax specification.
+For example, the &#8220;Molokai&#8221;, &#8220;Breakers&#8221;, and &#8220;Celeste&#8221; color schemes that ship with ST4 do not bother to highlight the list bullets, nor the fences around tables, nor any of the markers that start and end various blocks (examples, sidebar, etc.).</p>
+</div>
+<div class="paragraph">
+<p>To enable the &#8220;AsciiDoc Dark&#8221; scheme, or pick any other color scheme of your choice, simply pull down the &#8220;Preferences&#8221; menu and use &#8220;Select Color Scheme&#8230;&#8203;&#8221;.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-important" title="Important"></i>
+</td>
+<td class="content">
+Since this package is still very much under development, it is important that collaborators use an AsciiDoc-specific color scheme in order to appreciate/experience/test the syntax highlighting nuances.
+Many elements of the AsciiDoc syntax rely on (fine-grained) scope names which are peculiar to AsciiDoc, and very unlikely to be covered by general-purpose color schemes designed for programming languages or lightweight markup syntaxes (like Markdown, reST, etc.).
+</td>
+</tr>
+</table>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Fixed the syntax for ordered and unordered lists by changing punctuation.definition.list_item to just punctuation.definition.list (no _item) and adding .ordered or .unordered -- to be consistent with labeled lists.

Reverted markup.heading.0-5.asciidoc back to markup.heading.level.0-5.asciidoc (i.e. added .level back in)

Fixed AsciiDoc Dark's colorizing of block titles.